### PR TITLE
Fix exceptions during build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ghostdriver.log
-
+_win10_downloaded_contents
+geckodriver.log
+Powershell.tgz
 _build*

--- a/posh-to-dash.py
+++ b/posh-to-dash.py
@@ -40,11 +40,11 @@ class PoshWebDriver:
             binary = FirefoxBinary(executable_path)
             self.driver = webdriver.Firefox(
                 firefox_binary=binary,
-                firefox_options=options,
+                options=options,
             )
         else:
             self.driver = webdriver.Firefox(
-                firefox_options=options
+                options=options
             )
 
     def get_url_page(self, url):

--- a/posh-to-dash.py
+++ b/posh-to-dash.py
@@ -19,6 +19,7 @@ import collections
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from requests.exceptions import ConnectionError
 from bs4 import BeautifulSoup as bs, Tag # pip install bs4
 from selenium import webdriver
 from selenium.webdriver import Firefox
@@ -155,7 +156,15 @@ def download_textfile(url : str ,  output_filename : str, params : dict = None):
     # ensure the folder path actually exist
     os.makedirs(os.path.dirname(output_filename), exist_ok = True)
     
-    r = session.get(url, data = params)
+    while True:
+        try:
+            r = session.get(url, data = params)
+        except ConnectionError:
+            logging.debug("caught ConnectionError, retrying...")
+            time.sleep(2)
+        else:
+            break
+    
     with open(output_filename, 'w', encoding="utf8") as f:
         f.write(r.text)
 

--- a/posh-to-dash.py
+++ b/posh-to-dash.py
@@ -200,7 +200,8 @@ def download_module_contents(configuration, module_name, module_uri, module_dir,
     module_filepath = os.path.join(module_dir, "%s.html" % module_name)
 
     logging.debug("downloading %s module index page  -> %s" % (module_name, module_filepath))
-    download_page_contents(configuration, module_uri, module_filepath)
+    if module_uri:
+        download_page_contents(configuration, module_uri, module_filepath)
 
     cmdlets_infos = []
 
@@ -253,7 +254,7 @@ def crawl_posh_contents(configuration: Configuration, toc_url : str, download_di
     for module in modules:
 
         module_name = module['toc_title']
-        module_uri = module["href"]
+        module_uri = module.get("href")
         module_cmdlets = module['children']
         module_dir = os.path.join(download_dir, Configuration.base_url, module_name)
 


### PR DESCRIPTION
Fixes to a couple of issues that ocurred on my machine while trying to build the docset:
- Commit 8210eb5 is required for a successful build as in the latest TOC json wsus has no href property. 
- Commit 0b36430 is required to avoid the build process failing with a ConnectionError (this happened to me multiple times on different steps).

The rest are less important QOL fixes.